### PR TITLE
PackIt.Domain.Entities: Fix encapsulation violation in PackingList

### DIFF
--- a/src/PackIt.Domain/Entities/PackingList.cs
+++ b/src/PackIt.Domain/Entities/PackingList.cs
@@ -7,11 +7,11 @@ namespace PackIt.Domain.Entities
     /// </summary>
     internal class PackingList
     {
+        private string _name;
+        private string _localization;
         public Guid Id { get; private set; }
-        public string Name { get; private set; }
-        public string Localization { get; private set; }
-
+        
         public PackingList(string name, string localization)
-        => (this.Name, this.Localization) = (name, localization);
+        => (this._name, this._localization) = (name, localization);
     }
 }


### PR DESCRIPTION
Make public properties `Name` and `Localization` as private fileds to fix encapsulation violation.