### PR TITLE
Testing PackingList and PackingName

### DIFF
--- a/src/PackIt.Domain/Entities/PackingList.cs
+++ b/src/PackIt.Domain/Entities/PackingList.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using PackIt.Domain.ValueObjects;
+using System;
 
 namespace PackIt.Domain.Entities
 {
@@ -7,11 +8,11 @@ namespace PackIt.Domain.Entities
     /// </summary>
     internal class PackingList
     {
-        private string _name;
+        private PackingListName _name;
         private string _localization;
         public Guid Id { get; private set; }
         
-        public PackingList(string name, string localization)
+        public PackingList(PackingListName name, string localization)
         => (this._name, this._localization) = (name, localization);
     }
 }

--- a/src/PackIt.Domain/Exceptions/EmptyPackingListNameException.cs
+++ b/src/PackIt.Domain/Exceptions/EmptyPackingListNameException.cs
@@ -1,0 +1,12 @@
+﻿using PackIt.Shared.Abstractions.Exceptions;
+
+namespace PackIt.Domain.Exceptions
+{
+    public class EmptyPackingListNameException : PackItExceptionBase
+    {
+        public EmptyPackingListNameException() : base("Packing list name cannot be null or empty.")
+        {
+
+        }
+    }
+}

--- a/src/PackIt.Domain/ValueObjects/PackingListName.cs
+++ b/src/PackIt.Domain/ValueObjects/PackingListName.cs
@@ -1,6 +1,7 @@
 ﻿using PackIt.Domain.Exceptions;
 using System.Runtime.CompilerServices;
 
+[assembly: InternalsVisibleTo("PackIt.Tests.Domain")]
 namespace PackIt.Domain.ValueObjects;
 
 /// <summary>

--- a/src/PackIt.Domain/ValueObjects/PackingListName.cs
+++ b/src/PackIt.Domain/ValueObjects/PackingListName.cs
@@ -1,0 +1,30 @@
+﻿using PackIt.Domain.Exceptions;
+using System.Runtime.CompilerServices;
+
+namespace PackIt.Domain.ValueObjects;
+
+/// <summary>
+/// List name value object.
+/// </summary>
+public record PackingListName
+{
+    public string Value;
+    public PackingListName(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            throw new EmptyPackingListNameException();
+        
+        Value = value;
+    }
+
+    /// <summary>
+    /// Implicit conversion from string to PackingListName.
+    /// </summary>
+    /// <param name="name">Name of the packing list</param>
+    public static implicit operator PackingListName(string name) => new PackingListName(name);
+    /// <summary>
+    /// Implicit conversion from PackingListName to string.
+    /// </summary>
+    /// <param name="name"></param>
+    public static implicit operator string(PackingListName name) => name.Value;
+}

--- a/tests/PackIt.Tests.Domain/Entities/PackingListShouldNot.cs
+++ b/tests/PackIt.Tests.Domain/Entities/PackingListShouldNot.cs
@@ -1,0 +1,36 @@
+﻿using FluentAssertions;
+using PackIt.Domain.Entities;
+using PackIt.Domain.Exceptions;
+using System;
+using Xunit;
+namespace PackIt.Tests.Domain.Entities;
+
+public class PackingListShouldNot
+{
+    private const string _localization = "Cairo,Eygpt";
+    
+    [Theory]
+    [InlineData("", _localization)]       // Empty string
+    [InlineData(null, _localization)]     //null string
+    [InlineData(" ", _localization)]      // single White space
+    [InlineData("      ", _localization)] // White spaces
+    internal void AcceptEmptyName(string name, string localization)
+    {
+        // Arrange
+        PackingList packingList;
+        Type emptyNameExceptionType = typeof(EmptyPackingListNameException);
+        
+        try
+        {
+            // Act
+            packingList = new PackingList(name, localization);
+            // Assert
+            packingList.Should().NotBeOfType(emptyNameExceptionType);
+        }
+        catch (Exception e)
+        {
+            // Assert
+            e.Should().BeOfType(emptyNameExceptionType);
+        }
+    }
+}

--- a/tests/PackIt.Tests.Domain/ObjectValues/PackingListNameShould.cs
+++ b/tests/PackIt.Tests.Domain/ObjectValues/PackingListNameShould.cs
@@ -1,0 +1,33 @@
+﻿using FluentAssertions;
+using PackIt.Domain.ValueObjects;
+using Xunit;
+
+namespace PackIt.Tests.Domain.ObjectValues
+{
+    public class PackingListNameShould
+    {
+        [Fact]
+        internal void ImplicitlyConvertFromStringToPackingListName()
+        {
+            // Arrange
+            string stringfiedName = "Ahmed";
+            // Act
+            var valueObjectName = (PackingListName)stringfiedName;
+            // Assert
+            valueObjectName.Should().BeOfType(typeof(PackingListName));
+            valueObjectName.Value.Should().Be("Ahmed");
+        }
+
+        [Fact]
+        internal void ImplicitlyConvertFromPackingListNameToString()
+        {
+            // Arrange
+            PackingListName objectValueName = new("Ahmed");
+            // Act
+            var stringfiedName = (string)objectValueName;
+            // Assert
+            stringfiedName.Should().BeOfType(typeof(string));
+            stringfiedName.Should().Be("Ahmed");
+        }
+    }
+}

--- a/tests/PackIt.Tests.Domain/ObjectValues/PackingListNameShouldNot.cs
+++ b/tests/PackIt.Tests.Domain/ObjectValues/PackingListNameShouldNot.cs
@@ -1,0 +1,29 @@
+﻿using FluentAssertions;
+using PackIt.Domain.Exceptions;
+using PackIt.Domain.ValueObjects;
+using System;
+using Xunit;
+
+namespace PackIt.Tests.Domain.ObjectValues;
+
+public class PackingListNameShouldNot
+{
+    [Theory]
+    [InlineData("")]        // Empty string
+    [InlineData(null)]      //null string
+    [InlineData(" ")]       // single White space
+    [InlineData("      ")]  // White spaces
+    internal void AcceptEmptyString(string stringValue)
+    {
+        try
+        {
+            // Act
+            PackingListName? packingListName =  new PackingListName(stringValue);
+            packingListName.Should().NotBeOfType(typeof(PackingListName));
+        }
+        catch (Exception exption)
+        {
+            exption.Should().BeOfType(typeof(EmptyPackingListNameException));
+        }
+    }
+}


### PR DESCRIPTION
# Overview
Add test classes and cases to PackIt.Tests.Domain to test PackingList and PackingName entity and value object respectively.
The tests follows the convection of Should and ShouldNot.

## PackingList Test cases:
### Should not
1. Accept either empty, null or white space(s).

## PackingListName Test cases:
### Should
1. Be capable of implicit coversion from _string_ to valid _PackingListName_
2. Be capable of implicit conversion from _PackingListName_ to _string_
### Should not
1. Accept either empty, null or white space(s).